### PR TITLE
Add: Chrome extension boilerplate

### DIFF
--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,0 +1,18 @@
+{
+  "name": "gitCodeShare",
+  "version": "0.0.1",
+  "manifest_version": 2,
+  "author": "jsdev.kr",
+  "description": "Share your code beautifully. Anywhere.",
+  "homepage_url": "https://github.com/kosslab-kr/gitCodeShare.com",
+  "icons": {},
+  "background": {
+    "scripts": ["src/background.js"],
+    "persistent": false
+  },
+  "browser_action": {
+    "default_title": "gitCodeShare",
+    "default_popup": "src/popup.html"
+  },
+  "permissions": ["tabs", "activeTab", "https://www.facebook.com/*"]
+}

--- a/chrome-extension/src/background.js
+++ b/chrome-extension/src/background.js
@@ -1,0 +1,18 @@
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  if (changeInfo.status !== 'complete') return;
+
+  chrome.tabs.executeScript(
+    tabId,
+    {
+      code: 'var injected = window.gitCodeShare; window.gitCodeShare = true; injected;',
+      runAt: 'document_start',
+    },
+    res => {
+      if (chrome.runtime.lastError || res[0]) return;
+      chrome.tabs.executeScript(tabId, {
+        file: 'index.js', // TODO: This file name will be replace with our bundle file.
+        runAt: 'document_start',
+      });
+    },
+  );
+});

--- a/chrome-extension/src/index.js
+++ b/chrome-extension/src/index.js
@@ -1,0 +1,2 @@
+// This script is injected into the browser.
+console.log('injected!');

--- a/chrome-extension/src/popup.html
+++ b/chrome-extension/src/popup.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta http-equiv="X-UA-Compatible" content="ie=edge">
+	<style>
+		div {
+			width: 200px;
+			height: 200px;
+		}
+	</style>
+</head>
+
+<body>
+	<div>팝업 테스트</div>
+</body>
+
+</html>


### PR DESCRIPTION
Add Chrome Extension boilerplate code.

1. `manifest.json`
  - Chrome extension manifest file (configuration)
  - Ref: [Manifest File Format](https://developer.chrome.com/extensions/manifest)

1. `background.js`
  - Chrome extension background script ([Chrome API](https://developer.chrome.com/extensions/api_index))
  - Listening chrome event, injection script into browser tabs

1. `index.js`
  - Script to inject into browser tab. This will be replace with our bundle file.

1. `popup.html`
  - Static html file that popup when click extension icon
    
<img width="445" alt="image" src="https://user-images.githubusercontent.com/18487241/44616988-d6139080-a895-11e8-8384-58683889cd5e.png">

